### PR TITLE
Fix positional parameter issue in concatenation

### DIFF
--- a/Invoke-IntuneDocumentation.ps1
+++ b/Invoke-IntuneDocumentation.ps1
@@ -508,7 +508,7 @@ Add-WordText -FilePath $FullDocumentationPath -Heading Heading1 -Text "Device Ca
 $Cats = Get-IntuneDeviceCategory
 write-Log "Device Categories: $($Cats.count)"
 foreach($Cat in $Cats){
-Add-WordText -FilePath $FullDocumentationPath -Text " - " + $Cat.displayName -Size 10
+Add-WordText -FilePath $FullDocumentationPath -Text (" - " + $Cat.displayName) -Size 10
 }
 
 #endregion


### PR DESCRIPTION
This change ensures that the concatenation is done and the result passed as value to `-Text`.
This avoids errors like `Add-WordText : A positional parameter cannot be found that accepts argument '+'.`

This addresses one issue mentioned by @timmmay in #17 