### PR TITLE
Fix `Terms and Conditions` modification date

### DIFF
--- a/Invoke-IntuneDocumentation.ps1
+++ b/Invoke-IntuneDocumentation.ps1
@@ -380,7 +380,7 @@ write-Log "Terms and Conditions"
 $GAndT = Get-IntuneTermsAndConditions
 if($GAndT){
     Add-WordText -FilePath $FullDocumentationPath -Heading Heading1 -Text "Terms and Conditions"
-    $GAndT | ForEach-Object { $_ | Select-Object -Property id,createdDateTime,modifiedDateTime,displayName,title,version } | Add-WordTable -FilePath $FullDocumentationPath -AutoFitStyle Contents -Design LightListAccent2
+    $GAndT | ForEach-Object { $_ | Select-Object -Property id,createdDateTime,lastModifiedDateTime,displayName,title,version } | Add-WordTable -FilePath $FullDocumentationPath -AutoFitStyle Contents -Design LightListAccent2
 }
 #endregion
 #region Document EnrollmentRestrictions


### PR DESCRIPTION
I encountered an empty value in the `Terms and Conditions` table (resulting in the following cells being shifted to the left). This commit fixes the empty value by using the correct name of the property.


The property is now called `lastModifiedDateTime` as documented at
https://docs.microsoft.com/en-us/graph/api/intune-companyterms-termsandconditions-get?view=graph-rest-1.0#response-1