### PR TITLE
Adding support for outputting in Markdown format

### DIFF
--- a/PSModule/IntuneDocumentation/Data/Template.md
+++ b/PSModule/IntuneDocumentation/Data/Template.md
@@ -1,0 +1,5 @@
+# SYSTEM Documentation
+
+Generated on: DATE
+
+TENANT

--- a/PSModule/IntuneDocumentation/Internal/Add-Header.ps1
+++ b/PSModule/IntuneDocumentation/Internal/Add-Header.ps1
@@ -1,0 +1,30 @@
+function Add-Header {
+    <#
+    .SYNOPSIS
+    This function is used to add a header in the documentation.
+    .EXAMPLE
+    Add-Header -format 'md' -Text "Assignments" -level 2
+    Adds Assignments as a 2nd level heading in the 'md' format file at $FullDocumentationPath
+    .NOTES
+    NAME: Add-Header
+    #>    
+    param(
+        [Parameter(Mandatory = $true)]
+        [String]$format,
+
+        [Parameter(Mandatory = $true)]
+        [String]$Text,
+
+        [Parameter(HelpMessage = "Please choose a heading level between 1 and 6")]
+        [ValidateRange(1, 6)]
+        [int32]$level
+    )
+    
+    if ($format -eq 'md') {
+        # For markdown we already used a H1 for the doc Title, so to ensure proper header order 
+        # add 1 to the given header level
+        "$('#' * ($level + 1)) $Text`r`n" | Out-File -FilePath $FullDocumentationPath -Append -Encoding utf8
+    } else {
+        Add-WordText -FilePath $FullDocumentationPath -Heading "Heading$level" -Text $Text
+    }
+}

--- a/PSModule/IntuneDocumentation/Internal/Add-ScriptText.ps1
+++ b/PSModule/IntuneDocumentation/Internal/Add-ScriptText.ps1
@@ -1,0 +1,23 @@
+function Add-ScriptText {
+    <#
+    .SYNOPSIS
+    This function is used to add script content in the documentation.
+    .EXAMPLE
+    Add-ScriptText -format 'docx' -Text "Write-Log $Value"
+    Adds the text 'Write-Log $Value' formatted as code in the 'docx' format file at $FullDocumentationPath
+    .NOTES
+    NAME: Add-ScriptText
+    #>    
+    param(
+        [Parameter(Mandatory = $true)]
+        [String]$format,
+
+        [Parameter(Mandatory = $true)]
+        [String]$Text
+    )
+    if ($format -eq 'md') {
+        '```' + "`r`n$Text`r`n"  + '```' | Out-File -FilePath $FullDocumentationPath -Append -Encoding utf8
+    } else {
+        Add-WordText -FilePath $FullDocumentationPath -Text $Text -Size 10 -Italic -FontFamily "Courier New"
+    }
+}

--- a/PSModule/IntuneDocumentation/Internal/Add-Table.ps1
+++ b/PSModule/IntuneDocumentation/Internal/Add-Table.ps1
@@ -1,0 +1,31 @@
+function Add-Table {
+    <#
+    .SYNOPSIS
+    This function is used to add a table using an Object as input in the documentation.
+    .EXAMPLE
+    Add-Table -InputObject $Properties -format 'md'
+    Converts the $Properties object to a Markdown formatted table and adds to the 'md' format file at $FullDocumentationPath
+    .NOTES
+    NAME: Add-Table
+    #>     
+    param(
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true
+        )]
+        [PSObject[]]$InputObject,
+
+        [Parameter(Mandatory = $true)]
+        [String]$format,
+
+        [Parameter(Mandatory = $false)]
+        [String]$AutoFitStyle = 'Window'
+    )
+    process {
+        if ($format -eq 'md') {
+            ConvertTo-MD ($InputObject) | Out-File -FilePath $FullDocumentationPath -Append -Encoding utf8
+        } else {
+            $InputObject | Add-WordTable -FilePath $FullDocumentationPath -AutoFitStyle $AutoFitStyle -Design LightListAccent2 
+        }
+    }
+}

--- a/PSModule/IntuneDocumentation/Internal/Add-Text.ps1
+++ b/PSModule/IntuneDocumentation/Internal/Add-Text.ps1
@@ -1,0 +1,28 @@
+
+function Add-Text {
+    <#
+    .SYNOPSIS
+    This function is used to add a line of text in the documentation.
+    .EXAMPLE
+    Add-Text -format 'docx' -Text "Display Name"
+    Adds the text 'Display Name' in the 'docx' format file at $FullDocumentationPath
+    .NOTES
+    NAME: Add-Text
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [String]$format,
+
+        [Parameter(Mandatory = $true)]
+        [String]$Text,
+
+        [Parameter(Mandatory=$false, HelpMessage = "Please choose a font size between 4 and 72")]
+        [ValidateRange(4, 72)]
+        [Int32]$Size
+    )
+    if ($format -eq 'md') {
+        $Text | Out-File -FilePath $FullDocumentationPath -Append -Encoding utf8
+    } else {
+        Add-WordText -FilePath $FullDocumentationPath -Text $Text -Size $Size
+    }
+}

--- a/PSModule/IntuneDocumentation/Internal/ConvertTo-MD.ps1
+++ b/PSModule/IntuneDocumentation/Internal/ConvertTo-MD.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+   Converts a PowerShell object to a Markdown table. Based on ConvertTo-Markdown from https://github.com/ishu3101/PSMarkdown with added support
+   for multiple rows.
+.DESCRIPTION
+   The ConvertTo-MD function converts a Powershell Object to a Markdown formatted table
+.EXAMPLE
+   Get-Process | Where-Object {$_.mainWindowTitle} | Select-Object ID, Name, Path, Company | ConvertTo-MD
+   This command gets all the processes that have a main window title, and it displays them in a Markdown table format with the process ID, Name, Path and Company.
+.EXAMPLE
+   ConvertTo-MD (Get-Date)
+   This command converts a date object to Markdown table format
+.EXAMPLE
+   Get-Alias | Select Name, DisplayName | ConvertTo-MD
+   This command displays the name and displayname of all the aliases for the current session in Markdown table format
+#>
+Function ConvertTo-MD {
+    [CmdletBinding()]
+    [OutputType([string])]
+    Param (
+        [Parameter(
+            Mandatory = $true,
+            Position = 0,
+            ValueFromPipeline = $true
+        )]
+        [PSObject[]]$InputObject
+    )
+
+    Begin {
+        $items = @()
+        $columns = @{}
+    }
+
+    Process {
+        ForEach($item in $InputObject) {
+            $items += $item
+            $item.PSObject.Properties | ForEach-Object {
+                if($null -ne $_.Value){    
+                    if(-not $columns.Contains($_.Name) -or $columns[$_.Name] -lt $_.Value.ToString().Length) {
+                        $columns[$_.Name] = $_.Value.ToString().Length
+                    }
+                }
+            }
+        }
+    }
+
+    End {
+        ForEach($key in $($columns.Keys)) {
+            $columns[$key] = [Math]::Max($columns[$key], $key.Length)
+        }
+
+        $header = @()
+        ForEach($key in $columns.Keys) {
+            $header += ('{0,-' + $columns[$key] + '}') -f $key
+        }
+        [string]$HeaderToReturn = '| ' + ( $header -join ' | ' ) + ' |'
+
+        $separator = @()
+        ForEach($key in $columns.Keys) {
+            $separator += '-' * $columns[$key]
+        }
+        [string]$SeparatorToReturn = '| ' + ( $separator -join ' | ' ) + ' |'
+
+        [string]$ValuesToReturn = ""
+
+        ForEach($item in $items) {
+            $values = @()
+            ForEach($key in $columns.Keys) {
+                $values += ('{0,-' + $columns[$key] + '}') -f $item.($key)
+            }
+           $ValuesToReturn += '| ' + ( $values -join ' | ' ) + ' |' + "`r`n"
+        }
+       return [string]([string]::Concat($HeaderToReturn, "`n", $SeparatorToReturn, "`n", $ValuesToReturn))
+    }
+}

--- a/PSModule/IntuneDocumentation/Internal/Invoke-PrintAssignmentDetail.ps1
+++ b/PSModule/IntuneDocumentation/Internal/Invoke-PrintAssignmentDetail.ps1
@@ -17,7 +17,7 @@ Function Invoke-PrintAssignmentDetail(){
         if($Assignments){
             $ExtendedInfo = @()
             write-Log "Document assignments..."
-            Add-WordText -FilePath $FullDocumentationPath -Heading Heading3 -Text "Assignments"
+            Add-Header -level 3 -format $format -Text "Assignments"
             if($Assignments.count -gt 1){
                 foreach($Assignment in $Assignments){
                     $ExtendedInfo += Invoke-PrintAssignmentDetail_Assignment -Assignment $Assignment
@@ -26,9 +26,9 @@ Function Invoke-PrintAssignmentDetail(){
                 $ExtendedInfo += Invoke-PrintAssignmentDetail_Assignment -Assignment $Assignments
             }
             if($null -ne $ExtendedInfo){
-                $ExtendedInfo | Add-WordTable -FilePath $FullDocumentationPath -AutoFitStyle Window -Design LightListAccent2
+                Add-Table -InputObject $ExtendedInfo -format $format
             } else {
-                Add-WordText -FilePath $FullDocumentationPath -Text "No assignments"
+                Add-Text -format $format -Text "No assignments"
             }
         }
         

--- a/PSModule/IntuneDocumentation/Internal/Invoke-PrintGroup.ps1
+++ b/PSModule/IntuneDocumentation/Internal/Invoke-PrintGroup.ps1
@@ -56,6 +56,6 @@ Function Invoke-PrintGroup(){
         }
     }
     if($null -ne $GroupObjs){
-        $GroupObjs | Add-WordTable -FilePath $FullDocumentationPath -AutoFitStyle Window -Design LightListAccent2
+        Add-Table -InputObject $GroupObjs -format $format
     }
 }

--- a/PSModule/IntuneDocumentation/Internal/Invoke-PrintTableNormal.ps1
+++ b/PSModule/IntuneDocumentation/Internal/Invoke-PrintTableNormal.ps1
@@ -25,8 +25,16 @@ Function Invoke-PrintTableNormal(){
         
         if($null -eq $Value){
             $Value = ""
+        } elseif ($format -eq 'md') {
+            # Markdown has rendering issues with new lines in a table
+            $Value = ($Value -replace ('\r\n', '')) -replace ('\n','')
+            # some oma setting values are in xml format, wrap this part to avoid rendering issues
+            $pattern = [regex]'(.*)value=<(.*)'
+            if ($Value -match $pattern) {
+                $Value = $pattern.Replace($Value, '$1value=<code><$2</code>', 1)
+            }
         }
         $ht[$Name] = $Value
     }
-    ($ht.GetEnumerator() | Sort-Object -Property Name | Select-Object Name,Value) | Add-WordTable -FilePath $FullDocumentationPath -AutoFitStyle Window -Design LightListAccent2
+    Add-Table -InputObject ($ht.GetEnumerator() | Sort-Object -Property Name | Select-Object Name,Value) -format $format
 }

--- a/PSModule/IntuneDocumentation/Internal/Invoke-PrintTableTranslate.ps1
+++ b/PSModule/IntuneDocumentation/Internal/Invoke-PrintTableTranslate.ps1
@@ -102,8 +102,16 @@ Function Invoke-PrintTableTranslate(){
         }
         if($null -eq $Value){
             $Value = ""
+        } elseif ($format -eq 'md') {
+            # Markdown has rendering issues with new lines in a table
+            $Value = ($Value -replace ('\r\n', '')) -replace ('\n','')
+            # some oma setting values are in xml format, wrap this part to avoid rendering issues
+            $pattern = [regex]'(.*)value=<(.*)'
+            if ($Value -match $pattern) {
+                $Value = $pattern.Replace($Value, '$1value=<code><$2</code>', 1)
+            }
         }
         $ht[$Name] = $Value
     }
-    ($ht.GetEnumerator() | Sort-Object -Property Name | Select-Object Name,Value) | Add-WordTable -FilePath $FullDocumentationPath -AutoFitStyle Window -Design LightListAccent2
+    Add-Table -InputObject ($ht.GetEnumerator() | Sort-Object -Property Name | Select-Object Name,Value) -format $format
 }

--- a/PSModule/IntuneDocumentation/Internal/Update-Text.ps1
+++ b/PSModule/IntuneDocumentation/Internal/Update-Text.ps1
@@ -1,0 +1,27 @@
+function Update-Text {
+    <#
+    .SYNOPSIS
+    This function is used to replace text found in the documentation with a new value.
+    .EXAMPLE
+    Update-Text -format 'md' -SearchText "abc" -NewText "def"
+    Updates all occurences of 'abc' with 'def' in the 'md' format file at $FullDocumentationPath
+    .NOTES
+    NAME: Update-Text
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [String]$format,
+
+        [Parameter(Mandatory = $true)]
+        [String]$SearchText,
+
+        [Parameter(Mandatory = $true)]
+        [String]$NewText
+    )
+    
+    if ($format -eq 'md') {
+        ((Get-Content -path $FullDocumentationPath -Raw) -replace $SearchText, $NewText) | Set-Content -Path $FullDocumentationPath
+    } else {
+        Update-WordText -FilePath $FullDocumentationPath -ReplacingText $SearchText -NewText $NewText
+    }
+}


### PR DESCRIPTION
I tried to minimize changes to the existing code by creating proxy functions for writing content to the documentation. The extension of the FullDocumentationPath parameter will determine if Word or Markdown format is used. 

Closes #38.